### PR TITLE
[Major Fix] Java Package Naming

### DIFF
--- a/src/project/apis/computeapi/DigitalRootPersistenceAPI.java
+++ b/src/project/apis/computeapi/DigitalRootPersistenceAPI.java
@@ -1,0 +1,11 @@
+import project.annotations.ConceptualAPI;
+
+@ConceptualAPI
+public interface DigitalRootPersistenceAPI {
+    /**
+     * Method to process the number and find its digital root persistence.
+     * @param number the number to calculate the digital root persistence for
+     * @return a string with the results of the persistence count and the digital root
+     */
+    String processDigitalRootPersistence(int number);
+}

--- a/src/project/apis/computeapi/DigitalRootPersistenceAPIPrototype.java
+++ b/src/project/apis/computeapi/DigitalRootPersistenceAPIPrototype.java
@@ -1,0 +1,11 @@
+import project.annotations.ConceptualAPIPrototype;
+
+public class DigitalRootPersistenceAPIPrototype implements DigitalRootPersistenceAPI {
+
+    @Override
+    @ConceptualAPIPrototype
+    public String processDigitalRootPersistence(int number) {
+        // Simulated behavior: returning a static response (for testing)
+        return "Number " + number + " has a digital root persistence of 4 and final root 5";
+    }
+}

--- a/src/project/apis/computeapi/ImplementDigitalRootPersistenceAPI.java
+++ b/src/project/apis/computeapi/ImplementDigitalRootPersistenceAPI.java
@@ -1,0 +1,23 @@
+package project.apis.api_dataconnections;
+
+import project.apis.api_dataconnections.DigitalRootPersistenceAPI; // Ensure this path is correct
+import project.annotations.ConceptualAPIPrototype;
+
+/**
+ * Implementation of the DigitalRootPersistenceAPI.
+ * This class processes numbers to determine their digital root persistence.
+ */
+public class ImplementDigitalRootPersistenceAPI implements DigitalRootPersistenceAPI {
+
+    /**
+     * Processes the given number and calculates its digital root persistence.
+     * @param number the input number
+     * @return a placeholder response indicating unimplemented functionality
+     */
+    @Override
+    @ConceptualAPIPrototype
+    public String processDigitalRootPersistence(int number) {
+        // Placeholder implementation, returning a default response
+        return "Processing not yet implemented.";
+    }
+}


### PR DESCRIPTION
data-connections renamed to computeapi, java does not allow packages to be named with a hyphen so changed to computeapi for better naming consistency.