### PR TITLE
Update ImplementNetworkAPI.java

### DIFF
--- a/src/project/apis/networkapi/ImplementNetworkAPI.java
+++ b/src/project/apis/networkapi/ImplementNetworkAPI.java
@@ -5,6 +5,10 @@ import project.apis.networkapi.AskUser;
 import project.apis.networkapi.Window;
 import project.apis.networkapi.SendInfo;
 import project.apis.networkapi.ValidInfo;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Callable;
 
 import java.io.File;
 import java.util.List;
@@ -16,6 +20,8 @@ import java.util.List;
 public class ImplementNetworkAPI { 
 
     private final Screen screen;
+    private static final int THREAD_POOL_SIZE = 12;
+    private final ExecutorService executor;
 
     /**
      * Constructor accepting a Screen dependency.
@@ -71,4 +77,19 @@ public class ImplementNetworkAPI {
         SendInfo info = new ValidInfo(askUser); 
         return info;
     }
+
+        public void MultiThreadedNetworkAPI() {
+        this.executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+    }
+
+    // Method to execute API calls asynchronously
+    public Future<String> makeApiCall(Callable<String> apiTask) {
+        return executor.submit(apiTask);
+    }
+
+    // Shutdown method to clean up resources
+    public void shutdown() {
+        executor.shutdown();
+    }
+    
 }


### PR DESCRIPTION
Adds a Limit of 12 to the amount of threads that can be run at the same time. Adds methods to ensure they can run at the same time without error.