### PR TITLE
(Final Fixes) Implement gRPC data store, update build, and enable end-to-end testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,5 +97,20 @@ test {
 }
 
 application {
-    mainClass = 'project.Main'
+    mainClass = 'project.Main' // Default main class
+}
+
+// Run task: for  DataStorageApiGrpcServer
+task runDataStoreServer(type: JavaExec) {
+    group = 'application'
+    description = 'Run the DataStorageApiGrpcServer'
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'project.apis.datastorage.DataStorageApiGrpcServer'
+}
+
+// Print the full runtime classpath for manual java runs
+task printClasspath {
+    doLast {
+        println sourceSets.main.runtimeClasspath.asPath
+    }
 }

--- a/src/main/proto/datastorage.proto
+++ b/src/main/proto/datastorage.proto
@@ -1,0 +1,25 @@
+syntax = "proto2";
+
+package datastorage;
+
+service DataStorageAPI {
+    rpc ReadData (ReadDataRequest) returns (ReadDataResponse);
+    rpc WriteData (WriteDataRequest) returns (WriteDataResponse);
+}
+
+message ReadDataRequest {
+    required string key = 1;
+}
+
+message ReadDataResponse {
+    required bytes data = 1;
+}
+
+message WriteDataRequest {
+    required string key = 1;
+    required bytes data = 2;
+}
+
+message WriteDataResponse {
+    required bool success = 1;
+}

--- a/src/project/apis/datastorage/DataStorageApiGrpcClient.java
+++ b/src/project/apis/datastorage/DataStorageApiGrpcClient.java
@@ -1,0 +1,40 @@
+package project.apis.datastorage;
+
+import datastorage.Datastorage.*;
+import datastorage.DataStorageAPIGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+public class DataStorageApiGrpcClient implements DataStorageAPI {
+    private final DataStorageAPIGrpc.DataStorageAPIBlockingStub stub;
+
+    public DataStorageApiGrpcClient(String host, int port) {
+        ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+        stub = DataStorageAPIGrpc.newBlockingStub(channel);
+    }
+
+    @Override
+    public int[] readData(String key) throws Exception {
+        ReadDataRequest req = ReadDataRequest.newBuilder().setKey(key).build();
+        ReadDataResponse resp = stub.readData(req);
+        byte[] bytes = resp.getData().toByteArray();
+        int[] result = new int[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            result[i] = bytes[i];
+        }
+        return result;
+    }
+
+    @Override
+    public void writeData(String key, int[] data) throws Exception {
+        byte[] bytes = new byte[data.length];
+        for (int i = 0; i < data.length; i++) {
+            bytes[i] = (byte) data[i];
+        }
+        WriteDataRequest req = WriteDataRequest.newBuilder()
+            .setKey(key)
+            .setData(com.google.protobuf.ByteString.copyFrom(bytes))
+            .build();
+        stub.writeData(req);
+    }
+}

--- a/src/project/apis/datastorage/DataStorageApiGrpcServer.java
+++ b/src/project/apis/datastorage/DataStorageApiGrpcServer.java
@@ -1,0 +1,42 @@
+package project.apis.datastorage;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import datastorage.Datastorage.*;
+import datastorage.DataStorageAPIGrpc;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
+
+public class DataStorageApiGrpcServer {
+    public static void main(String[] args) throws IOException, InterruptedException {
+        Server server = ServerBuilder.forPort(9090)
+            .addService(new DataStorageApiServiceImpl())
+            .build();
+        System.out.println("DataStorageAPI gRPC server started on port 9090");
+        server.start();
+        server.awaitTermination();
+    }
+
+    static class DataStorageApiServiceImpl extends DataStorageAPIGrpc.DataStorageAPIImplBase {
+        private final Map<String, byte[]> store = new ConcurrentHashMap<>();
+
+        @Override
+        public void readData(ReadDataRequest request, StreamObserver<ReadDataResponse> responseObserver) {
+            byte[] data = store.getOrDefault(request.getKey(), new byte[0]);
+            ReadDataResponse response = ReadDataResponse.newBuilder().setData(com.google.protobuf.ByteString.copyFrom(data)).build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void writeData(WriteDataRequest request, StreamObserver<WriteDataResponse> responseObserver) {
+            store.put(request.getKey(), request.getData().toByteArray());
+            WriteDataResponse response = WriteDataResponse.newBuilder().setSuccess(true).build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/src/project/apis/networkapi/FileIOHandler.java
+++ b/src/project/apis/networkapi/FileIOHandler.java
@@ -1,3 +1,5 @@
+package project.apis.networkapi;
+
 import java.io.*;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/test/project/annotations/FileIOHandlerTest.java
+++ b/test/project/annotations/FileIOHandlerTest.java
@@ -1,8 +1,13 @@
+package project.apis.datastorage;
+
 import org.junit.jupiter.api.Test;
+import project.apis.networkapi.FileIOHandler;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class FileIOHandlerTest {


### PR DESCRIPTION
<img width="466" alt="Screenshot 2025-04-14 at 11 40 21 PM" src="https://github.com/user-attachments/assets/6cccf1a2-d3f0-41d5-9724-2d043c0b7660" />

As of this merge all tests passes and manual testing works.

## Key Changes & Fixes

- **Implemented gRPC Data Store:**
  - Added a gRPC server for the DataStorageAPI (`DataStorageApiGrpcServer`).
  - Added a gRPC client (`DataStorageApiGrpcClient`) that implements the same interface as the in-memory data store.


- **Build & Run Improvements:**
  - Updated `build.gradle` to support multiple run targets (`run` for the main app, `runDataStoreServer` for the data store server).
     I did this to avoid switching between target runs, hence ./gradlew runDataStoreServer
  - Added a `printClasspath` Gradle task to easily obtain the full runtime classpath for manual runs.



Side note:
This is how I did the end to end testing: 

1. **Start the Data Store gRPC Server**  
   In one terminal:
   ```sh
   ./gradlew runDataStoreServer
   ```

2. **Get the Full Classpath for Manual Run**  
   In another terminal:
   ```sh
   ./gradlew printClasspath
   ```
   Copy the output (a long colon-separated list).

3. **Run the Main Application**
   In the same terminal:
   Example:
   ```sh
   java -cp "build/classes/java/main:build/resources/main:..." project.Main
   ```







